### PR TITLE
Allow number of cores to be forced for debugging

### DIFF
--- a/SingleRunOptionsHandler.pm
+++ b/SingleRunOptionsHandler.pm
@@ -65,12 +65,12 @@ sub print_usage {
   there are also several optional arguments:
     -h   this help
     -v # set verbosity level 1(lowest) through 5  (currently not implemented)
-    -n # set the number of cores to utilize 
+    -n # set the number of cores to utilize
          (defaults to (available - 2), as reported by /proc/cpuinfo; or 1)
     -C # set probability threshold where # is of the form 1e-15 (defaults to 1e-12)
     -D   set sort directory (default is "sortdir" in the current directory)
     -R   set root name for calculation directory (default is "calculator")
-    -o   only create dictionary.zip (stage1), then stop    
+    -o   only create dictionary.zip (stage1), then stop
     -d   if specified the script will automatically delete files as it
          progresses through each experiment stage
     -g   include patterns for unseen terminals in the PCFG specification
@@ -161,14 +161,14 @@ sub set_cores {
         `cat /proc/meminfo | grep ^MemFree| grep -o \'[0-9]\\{1,\\}\'`
     );
     if (!$mem1 =~ /^\d+$/) {
-      die "odd, MemFree in /proc/meminfo is not a number: $mem1 \n";
+      print STDERR "odd, MemFree in /proc/meminfo is not a number: $mem1 \n";
     }
     chomp(
       my $mem2 =
         `cat /proc/meminfo | grep ^Cached| grep -o \'[0-9]\\{1,\\}\'`
     );
     if (!$mem2 =~ /^\d+$/) {
-      die "odd, Cached in /proc/meminfo is not a number: $mem2 \n";
+      print STDERR "odd, Cached in /proc/meminfo is not a number: $mem2 \n";
     }
     my $mem = $mem1 + $mem2;
     print STDERR "found "
@@ -179,7 +179,7 @@ sub set_cores {
       . $mem
       . "kb total\n";
     $mem -= $ramreserve;       #subtract out the ramdisk
-    if ($mem < 0) {
+    if ($mem <= 0) {
       $mem = 2000 * 1024;
     }
     print STDERR "using " . $mem . "kb of RAM after reserving some for system.";


### PR DESCRIPTION
### Issue

Macs don't have a `/proc` directory so the code in the framework that gets cpu and memory information from there does not work.

### Resolution

Allow those calls to fail but allow the user to force a number of cores.  This is also useful for reproducing user issues where the user has lots of a cores.  Alternatively, we could set cores to 1 if not detected, but this would not be useful for debugging.

For future reference, I was able to build and run the test described in `USAGE.md` on my Mac using a Nix shell:
```
curl https://nixos.org/nix/install | sh
. /Users/saranga/.nix-profile/etc/profile.d/nix.sh
nix-env -i coreutils-8.27
nix-shell -p bash
export LC_ALL=C
```